### PR TITLE
feat: add cname to config js.org

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -17,7 +17,7 @@ type SidebarItem = (StarlightUserConfig['sidebar'] & object)[number]
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://radashi-org.github.io',
+  site: 'https://radashi.js.org',
   integrations: [
     mdAstro(),
     starlight({

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+radashi.js.org


### PR DESCRIPTION
# Summary 

The first step to config the [js.org](https://js.org/) domain.

I created the CNAME file.

# Related issue 

https://github.com/orgs/radashi-org/discussions/183

# After merge 

1.  @aleclarson I need your help [adding JS.ORG with a custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain) on Github Pages
2. I'm going to submit a PR to the [js.org repository.](https://github.com/js-org/js.org) 