### PR TITLE
chore: use new documentation domain

### DIFF
--- a/src/content/docs/blog/vs-radash.mdx
+++ b/src/content/docs/blog/vs-radash.mdx
@@ -71,13 +71,13 @@ That said, let me give you an overview of how the two projects compare, given th
   - The docs will be explicit about which browsers are supported by Radashi without the need for legacy transforms.
   - This page will be updated every time the docs are updated, so it's always relatively up-to-date.
   - As part of our automatic linting process, we verify that this browser support is not broken.
-  - You can find the page [here](https://radashi-org.github.io/browser-support/).
+  - You can find the page [here](https://radashi.js.org/browser-support/).
 
 - **“Lodash parity” page**
 
   - The docs will have a page dedicated to comparing Radashi and Lodash where overlap exists.
   - This should help Lodash users make the switch to Radashi.
-  - When the page is ready, you'll be able to find it [here](https://radashi-org.github.io/lodash-parity/). (I'm almost done writing this page. It's generated from a Supabase table where I keep track of which Lodash functions have been implemented in Radashi.)
+  - When the page is ready, you'll be able to find it [here](https://radashi.js.org/lodash-parity/). (I'm almost done writing this page. It's generated from a Supabase table where I keep track of which Lodash functions have been implemented in Radashi.)
 
 - **Other small things**
   <details>

--- a/src/util/castComparator.ts
+++ b/src/util/castComparator.ts
@@ -25,7 +25,7 @@ import {
  * negative number means the “left value” is greater than the “right
  * value”, and 0 means both values are equal.
  *
- * @see https://radashi-org.github.io/reference/function/castComparator
+ * @see https://radashi.js.org/reference/function/castComparator
  * @example
  * ```ts
  * const compareUserNames = castComparator(
@@ -126,7 +126,7 @@ export function castComparator(
  * A value that describes how a comparator maps the input values to a
  * comparable value.
  *
- * @see https://radashi-org.github.io/reference/function/castComparator
+ * @see https://radashi.js.org/reference/function/castComparator
  */
 export type ComparatorMapping<
   T = any,

--- a/src/util/dedent.ts
+++ b/src/util/dedent.ts
@@ -10,7 +10,7 @@ import { isArray } from 'radashi'
  * most use cases, so you should only set an explicit `indent` if
  * necessary.
  *
- * @see https://radashi-org.github.io/reference/string/dedent
+ * @see https://radashi.js.org/reference/string/dedent
  * @example
  * ```ts
  * // This is indented with 4 spaces.


### PR DESCRIPTION
# Summary
Update all places that used the old domain for the [radashi.js.org](https://radashi.js.org/) domain.

Update some missing links.

# Related issue, if any:
https://github.com/orgs/radashi-org/discussions/183
https://github.com/radashi-org/radashi/pull/206