### PR TITLE
feat: add since tag

### DIFF
--- a/src/pages/reference/[group]/[fn].astro
+++ b/src/pages/reference/[group]/[fn].astro
@@ -13,6 +13,7 @@ interface StaticParams {
 interface Frontmatter {
   title: string
   description: string
+  since: string
 }
 
 interface Props {
@@ -52,7 +53,8 @@ const {
     id="heft"
     href={`https://github.com/radashi-org/radashi/blob/main/src/${Astro.url.pathname.replace(/\/reference\//, '').replace(/\/$/, '')}.ts`}
     target="_blank"
-    class="inline-block translate-y--20% translate-x-1rem no-underline"
+    class="inline-block translate-y--20% translate-x-1rem no-underline mr-0.4rem"
+    title={`access the source code of ${frontmatter.title}`}
   >
     <div
       class="px-0.8rem py-0.4rem bg-#bddef2 color-[hsl(224,_10%,_10%)] rounded-full text-0.8rem font-500"
@@ -60,10 +62,24 @@ const {
       <strong class="font-700">{heft[frontmatter.title]}</strong> bytes
     </div>
   </a>
+  <a
+    id="since"
+    href={`https://github.com/radashi-org/radashi/tree/v${frontmatter.since}`}
+    target="_blank"
+    class="inline-block translate-y--20% translate-x-1rem no-underline"
+    title={`view the repository at v${frontmatter.since}`}
+  >
+    <div
+      class="px-0.8rem py-0.4rem bg-#F69D50 color-[hsl(224,_10%,_10%)] rounded-full text-0.8rem font-500"
+    >
+      since <strong class="font-700">v{frontmatter.since}</strong>
+    </div>
+  </a>
   <Content />
 
   <script is:inline define:vars={{ title: frontmatter.title }}>
     const h1 = document.querySelector(':not(.is-previous-container) h1')
     h1.append(document.getElementById('heft'))
+    h1.append(document.getElementById('since'))
   </script>
 </StarlightPage>


### PR DESCRIPTION
###  Summary 

Add the `since` tag

![image](https://github.com/user-attachments/assets/7d70f806-ab85-4122-a600-ec19d1596634)
![image](https://github.com/user-attachments/assets/e2d1f65e-15fe-435e-8e5e-5d3d9a83f8da)
![image](https://github.com/user-attachments/assets/04f8608a-c5cc-4e43-93b3-68baff03dd9a)

and add a title to the `byte` tag to improve the “hover experience” 

![image](https://github.com/user-attachments/assets/34a6d352-3aa3-4904-a936-1a00174a534b)

### Related: 
https://github.com/radashi-org/radashi/pull/246

### How test locally

As the [PR for radashi](https://github.com/user-attachments/assets/34a6d352-3aa3-4904-a936-1a00174a534b) has not yet been approved to run this PR locally, we have to take some steps

1. after initial setup of the repository, access the `radashi` folder
2. run:
     ```bash
     git fetch origin pull/246/head:feature/add-versions
     git checkout feature/add-versions
     ```
4. comment the line number `85` in the file `astro.config.ts`
     ![image](https://github.com/user-attachments/assets/6b8ae057-4706-4540-aafe-2549831ac96d)
5. run  `pnpm dev`

