### PR TITLE
feat: generate llms.txt for LLM-friendly documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ pnpm-debug.log*
 
 # generated files
 src/content/docs/reference/index.mdx
+public/llms.txt
+public/llms-full.txt
 
 # build output
 dist/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,7 @@ import { group, title } from 'radashi'
 import { globSync } from 'tinyglobby'
 import virtual from 'vite-plugin-virtual'
 import { renderHeftJson } from './scripts/render-heft-json'
+import { renderLlmsTxt } from './scripts/render-llms-txt'
 import { renderReferenceIndex } from './scripts/render-reference-index'
 
 type SidebarItem = (StarlightUserConfig['sidebar'] & object)[number]
@@ -96,6 +97,11 @@ async function radashi() {
   const content = await renderReferenceIndex()
   mkdirSync('src/content/docs/reference', { recursive: true })
   writeFileSync('src/content/docs/reference/index.mdx', content)
+
+  console.log('Generating llms.txt files...')
+  const llmsTxt = await renderLlmsTxt()
+  writeFileSync('public/llms.txt', llmsTxt.index)
+  writeFileSync('public/llms-full.txt', llmsTxt.full)
 
   return [
     virtual({

--- a/scripts/render-llms-txt.ts
+++ b/scripts/render-llms-txt.ts
@@ -1,0 +1,150 @@
+import matter, { GrayMatterFile } from 'gray-matter'
+import { readFile } from 'node:fs/promises'
+import { capitalize, group } from 'radashi'
+import { globSync } from 'tinyglobby'
+
+const categoryDescriptions: Record<string, string> = {
+  array: 'Array manipulation and transformation',
+  async: 'Async/await utilities and control flow',
+  curry: 'Function composition and partial application',
+  function: 'Function utilities and helpers',
+  number: 'Numeric operations and parsing',
+  object: 'Object manipulation and transformation',
+  oop: 'Object-oriented patterns and classes',
+  random: 'Random value generation',
+  series: 'Series and sequence operations',
+  string: 'String transformation and formatting',
+  typed: 'Type guards and type checking',
+}
+
+const nameOverrides: Record<string, string> = {
+  oop: 'OOP',
+}
+
+type FunctionInfo = {
+  title: string
+  description: string
+}
+
+type FunctionEntry = {
+  slug: string
+  category: string
+  data: FunctionInfo
+  content: string
+}
+
+export async function renderLlmsTxt() {
+  const entries: FunctionEntry[] = []
+
+  for (const file of globSync('radashi/docs/**/*.mdx').sort()) {
+    const slug = file
+      .replace(/\.mdx$/, '')
+      .split('/')
+      .slice(2)
+      .join('/')
+
+    const raw = await readFile(file, 'utf8')
+    const { data, content } = matter(raw) as GrayMatterFile<string> & {
+      data: FunctionInfo
+    }
+
+    entries.push({
+      slug,
+      category: slug.split('/')[0],
+      data,
+      content: content.trim(),
+    })
+  }
+
+  const grouped = group(entries, e => e.category)
+
+  return {
+    index: renderIndex(grouped),
+    full: renderFull(grouped),
+  }
+}
+
+function categoryName(category: string) {
+  return nameOverrides[category] ?? capitalize(category)
+}
+
+function renderIndex(grouped: Partial<Record<string, FunctionEntry[]>>) {
+  const lines: string[] = [
+    '# Radashi',
+    '',
+    '> A TypeScript utility toolkit with lightweight, readable, performant, and robust functions.',
+    '>',
+    '> - Tree-shakeable, dependency-free, type-safe',
+    '> - Full test coverage, actively maintained',
+    '> - https://radashi.js.org',
+    '',
+    'For complete documentation of each function, see [llms-full.txt](https://radashi.js.org/llms-full.txt).',
+    '',
+  ]
+
+  for (const [category, entries] of Object.entries(grouped)) {
+    if (!entries) continue
+    const desc = categoryDescriptions[category] ?? ''
+    lines.push(`## ${categoryName(category)}`)
+    if (desc) {
+      lines.push('')
+      lines.push(desc)
+    }
+    lines.push('')
+
+    for (const entry of entries) {
+      const url = `https://radashi.js.org/reference/${entry.slug}`
+      lines.push(`- [${entry.data.title}](${url}): ${entry.data.description}`)
+    }
+
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function renderFull(grouped: Partial<Record<string, FunctionEntry[]>>) {
+  const lines: string[] = [
+    '# Radashi',
+    '',
+    '> A TypeScript utility toolkit with lightweight, readable, performant, and robust functions.',
+    '',
+    '## Installation',
+    '',
+    '```sh',
+    'npm install radashi',
+    '```',
+    '',
+    '## Usage',
+    '',
+    '```ts',
+    "import * as _ from 'radashi'",
+    '',
+    '// Or import individual functions',
+    "import { unique, retry, pick } from 'radashi'",
+    '```',
+    '',
+  ]
+
+  for (const [category, entries] of Object.entries(grouped)) {
+    if (!entries) continue
+    const desc = categoryDescriptions[category] ?? ''
+    lines.push(`## ${categoryName(category)}`)
+    if (desc) {
+      lines.push('')
+      lines.push(desc)
+    }
+    lines.push('')
+
+    for (const entry of entries) {
+      lines.push(`### ${entry.data.title}`)
+      lines.push('')
+      lines.push(entry.data.description)
+      lines.push('')
+      lines.push(entry.content)
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
#### Description

Adds automatic generation of `llms.txt` files during the docs build, following the [llms.txt standard](https://llmstxt.org/).

**What it does:**

The build now generates two files in `public/`:
- `llms.txt` (~16KB) — index of all functions with descriptions and links
- `llms-full.txt` (~128KB) — complete documentation in a single file

These files help AI coding assistants (Cursor, Copilot, Claude, etc.) understand the Radashi API without scraping the entire site.

**Implementation:**

- New `scripts/render-llms-txt.ts` reads MDX files from `radashi/docs/`, groups them by category, and outputs markdown
- Called from the `radashi()` Vite plugin in `astro.config.ts` alongside existing reference index generation
- Generated files are gitignored since they're created at build time

**Result:**

After deployment, the files will be available at:
- https://radashi.js.org/llms.txt
- https://radashi.js.org/llms-full.txt